### PR TITLE
fix this issue: TypeError: 'module' object is not callable

### DIFF
--- a/custom_components/climate/mi_acpartner.py
+++ b/custom_components/climate/mi_acpartner.py
@@ -286,7 +286,7 @@ class MiAcPartner(ClimateDevice):
         import miio
         if not self._climate:
             _LOGGER.info("initializing with host %s token %s" % (self.host, self.token))
-            self._climate = miio.device(self.host, self.token)
+            self._climate = miio.Device(self.host, self.token)
         return self._climate
 
     @property


### PR DESCRIPTION
make it work with python-miio 0.3.1 version